### PR TITLE
Fix page title

### DIFF
--- a/1.1/mal_block_synopsis.page
+++ b/1.1/mal_block_synopsis.page
@@ -20,7 +20,7 @@
   <desc>Create an overview of concepts.</desc>
 </info>
 
-<title>Synopses</title>
+<title>Synopsis</title>
 
 <p>Use the <code>synopsis</code> element to mark up a block that provides
 an overview of the material being presented.  A synopsis is useful for


### PR DESCRIPTION
The page title was “Synopses”, while the element is “synopsis”.